### PR TITLE
Fixed the problem of illegal path when decompressing *.BNK files of HOTD4 (PS3 Japan), Rambo (Arcade), SEGA GoldGun (Arcade)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Sega NN tools",
     "description": "Tools to import models using the NN libraries and some",
-    "author": "Arg!! (Special thanks to Sewer56, Yacker, firegodjr and Shadowth117!)",
+    "author": "Arg!! (Special Thanks to Sewer56, Yacker, firegodjr and Shadowth117!)",
     "version": (0, 8, 0),
     "blender": (4, 1, 0),
     "location": "3d View > Sidebar",

--- a/extract/bnk.py
+++ b/extract/bnk.py
@@ -55,6 +55,7 @@ class ExtractBnk:
         data = f.read(block_len)
 
         file_path = bpy.path.native_pathsep(self.file[:-4] + "_Extracted" + "/" + name)
+
         pathlib.Path(file_path).parent.mkdir(parents=True, exist_ok=True)
 
         fn = open(file_path, "wb")
@@ -93,6 +94,9 @@ class ExtractBnk:
             tex_name = img_names[i]
 
             file_path = bpy.path.native_pathsep(self.file[:-4] + "_Extracted" + "/" + tex_name)
+            # Check whether the file_path path is legal
+            if file_path.count(":") > 1:
+                file_path = file_path.split(":")[0]+":"+file_path.split(":")[1]+file_path.split(":")[2]
             pathlib.Path(file_path).parent.mkdir(parents=True, exist_ok=True)
 
             fn = open(file_path, "wb")


### PR DESCRIPTION
### Illegal path
In the Japanese PS3 version of House of the dead 4（DISC ID:NPJB00198）, SEGA used the path of the DDS texture file as the file name, which caused the bnk extract tool to have an illegal path when pathlib.mkdir

![image](https://github.com/user-attachments/assets/ddc33333-8dfd-45b9-b78c-64f5e7fa707f)

This situation also occurs in the arcade games Rambo and SEGA GoldGun, which are also developed using the SEGA NN engine.

### Solution

I added some checking code before the mkdir so that if an illegal file name is detected, the script will treat the drive letter as a folder instead of omitting it, which may help others writing recompression scripts.




